### PR TITLE
Eliminate 2013 references in *.2015.vcxproj files

### DIFF
--- a/FreeImage.2015.vcxproj
+++ b/FreeImage.2015.vcxproj
@@ -26,25 +26,25 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>DynamicLibrary</ConfigurationType>
-    <PlatformToolset>v120_xp</PlatformToolset>
+    <PlatformToolset>v140_xp</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
@@ -417,39 +417,39 @@ copy Source\FreeImage.h Dist\x64
     <Text Include="Whatsnew.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="Source\LibJPEG\LibJPEG.2013.vcxproj">
+    <ProjectReference Include="Source\LibJPEG\LibJPEG.2015.vcxproj">
       <Project>{5e1d4e5f-e10c-4ba3-b663-f33014fd21d9}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="Source\LibJXR\LibJXR.2013.vcxproj">
+    <ProjectReference Include="Source\LibJXR\LibJXR.2015.vcxproj">
       <Project>{244455e0-5f25-4451-9540-f317883e52a8}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="Source\LibOpenJPEG\LibOpenJPEG.2013.vcxproj">
+    <ProjectReference Include="Source\LibOpenJPEG\LibOpenJPEG.2015.vcxproj">
       <Project>{e3536c28-a7f1-4b53-8e52-7d2232f9e098}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="Source\LibPNG\LibPNG.2013.vcxproj">
+    <ProjectReference Include="Source\LibPNG\LibPNG.2015.vcxproj">
       <Project>{7db10b50-ce00-4d7a-b322-6824f05d2fcb}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="Source\LibRawLite\LibRawLite.2013.vcxproj">
+    <ProjectReference Include="Source\LibRawLite\LibRawLite.2015.vcxproj">
       <Project>{07f662c1-1323-42ab-b6af-fbfd34a7437a}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="Source\LibTIFF4\LibTIFF4.2013.vcxproj">
+    <ProjectReference Include="Source\LibTIFF4\LibTIFF4.2015.vcxproj">
       <Project>{ec085cbd-e9c3-477f-9a97-cb9d5da30e27}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="Source\LibWebP\LibWebP.2013.vcxproj">
+    <ProjectReference Include="Source\LibWebP\LibWebP.2015.vcxproj">
       <Project>{097d9f6c-fd0e-4cbc-9676-009012aaeca8}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="Source\OpenEXR\OpenEXR.2013.vcxproj">
+    <ProjectReference Include="Source\OpenEXR\OpenEXR.2015.vcxproj">
       <Project>{17a4874b-0606-4687-90b6-f91f8cb3b8af}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="Source\ZLib\ZLib.2013.vcxproj">
+    <ProjectReference Include="Source\ZLib\ZLib.2015.vcxproj">
       <Project>{33134f61-c1ad-4b6f-9cea-503a9f140c52}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/Source/FreeImageLib/FreeImageLib.2015.vcxproj
+++ b/Source/FreeImageLib/FreeImageLib.2015.vcxproj
@@ -353,39 +353,39 @@ copy ..\FreeImage.h ..\..\Dist\x64
     <Text Include="..\..\Whatsnew.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\LibJPEG\LibJPEG.2013.vcxproj">
+    <ProjectReference Include="..\LibJPEG\LibJPEG.2015.vcxproj">
       <Project>{5e1d4e5f-e10c-4ba3-b663-f33014fd21d9}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\LibJXR\LibJXR.2013.vcxproj">
+    <ProjectReference Include="..\LibJXR\LibJXR.2015.vcxproj">
       <Project>{244455e0-5f25-4451-9540-f317883e52a8}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\LibOpenJPEG\LibOpenJPEG.2013.vcxproj">
+    <ProjectReference Include="..\LibOpenJPEG\LibOpenJPEG.2015.vcxproj">
       <Project>{e3536c28-a7f1-4b53-8e52-7d2232f9e098}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\LibPNG\LibPNG.2013.vcxproj">
+    <ProjectReference Include="..\LibPNG\LibPNG.2015.vcxproj">
       <Project>{7db10b50-ce00-4d7a-b322-6824f05d2fcb}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\LibRawLite\LibRawLite.2013.vcxproj">
+    <ProjectReference Include="..\LibRawLite\LibRawLite.2015.vcxproj">
       <Project>{07f662c1-1323-42ab-b6af-fbfd34a7437a}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\LibTIFF4\LibTIFF4.2013.vcxproj">
+    <ProjectReference Include="..\LibTIFF4\LibTIFF4.2015.vcxproj">
       <Project>{ec085cbd-e9c3-477f-9a97-cb9d5da30e27}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\LibWebP\LibWebP.2013.vcxproj">
+    <ProjectReference Include="..\LibWebP\LibWebP.2015.vcxproj">
       <Project>{097d9f6c-fd0e-4cbc-9676-009012aaeca8}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\OpenEXR\OpenEXR.2013.vcxproj">
+    <ProjectReference Include="..\OpenEXR\OpenEXR.2015.vcxproj">
       <Project>{17a4874b-0606-4687-90b6-f91f8cb3b8af}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\ZLib\ZLib.2013.vcxproj">
+    <ProjectReference Include="..\ZLib\ZLib.2015.vcxproj">
       <Project>{33134f61-c1ad-4b6f-9cea-503a9f140c52}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/Source/LibPNG/LibPNG.2015.vcxproj
+++ b/Source/LibPNG/LibPNG.2015.vcxproj
@@ -224,7 +224,7 @@
     <ClInclude Include="pngstruct.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ZLib\ZLib.2013.vcxproj">
+    <ProjectReference Include="..\ZLib\ZLib.2015.vcxproj">
       <Project>{33134f61-c1ad-4b6f-9cea-503a9f140c52}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/Source/LibRawLite/LibRawLite.2015.vcxproj
+++ b/Source/LibRawLite/LibRawLite.2015.vcxproj
@@ -194,7 +194,7 @@
     <ClInclude Include="libraw\libraw_version.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\LibJPEG\LibJPEG.2013.vcxproj">
+    <ProjectReference Include="..\LibJPEG\LibJPEG.2015.vcxproj">
       <Project>{5e1d4e5f-e10c-4ba3-b663-f33014fd21d9}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/Source/LibTIFF4/LibTIFF4.2015.vcxproj
+++ b/Source/LibTIFF4/LibTIFF4.2015.vcxproj
@@ -245,11 +245,11 @@
     <ClInclude Include="uvcode.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\LibJPEG\LibJPEG.2013.vcxproj">
+    <ProjectReference Include="..\LibJPEG\LibJPEG.2015.vcxproj">
       <Project>{5e1d4e5f-e10c-4ba3-b663-f33014fd21d9}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>
-    <ProjectReference Include="..\ZLib\ZLib.2013.vcxproj">
+    <ProjectReference Include="..\ZLib\ZLib.2015.vcxproj">
       <Project>{33134f61-c1ad-4b6f-9cea-503a9f140c52}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/Source/OpenEXR/OpenEXR.2015.vcxproj
+++ b/Source/OpenEXR/OpenEXR.2015.vcxproj
@@ -486,7 +486,7 @@
     <ClInclude Include="IexMath\IexMathIeeeExc.h" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\ZLib\ZLib.2013.vcxproj">
+    <ProjectReference Include="..\ZLib\ZLib.2015.vcxproj">
       <Project>{33134f61-c1ad-4b6f-9cea-503a9f140c52}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/TestAPI/Test.2015.vcxproj
+++ b/TestAPI/Test.2015.vcxproj
@@ -26,25 +26,25 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>

--- a/Wrapper/FreeImagePlus/FreeImagePlus.2015.vcxproj
+++ b/Wrapper/FreeImagePlus/FreeImagePlus.2015.vcxproj
@@ -312,7 +312,7 @@ copy FreeImagePlus.h dist\x64</Command>
     <Text Include="WhatsNew_FIP.txt" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\Source\FreeImageLib\FreeImageLib.2013.vcxproj">
+    <ProjectReference Include="..\..\Source\FreeImageLib\FreeImageLib.2015.vcxproj">
       <Project>{9e219df2-315d-478e-8a07-8960c377ce1e}</Project>
       <ReferenceOutputAssembly>false</ReferenceOutputAssembly>
     </ProjectReference>

--- a/Wrapper/FreeImagePlus/test/fipTest.2015.vcxproj
+++ b/Wrapper/FreeImagePlus/test/fipTest.2015.vcxproj
@@ -25,25 +25,25 @@
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
     <ConfigurationType>Application</ConfigurationType>
-    <PlatformToolset>v120</PlatformToolset>
+    <PlatformToolset>v140</PlatformToolset>
     <UseOfMfc>false</UseOfMfc>
     <CharacterSet>MultiByte</CharacterSet>
   </PropertyGroup>


### PR DESCRIPTION
## Eliminate 2013 references in *.2015.vcxproj files

### Symptom:
Attempting to compile this FreeImage solution with VS2015 fails because the VS2013 toolset is not installed. 

### Discussion:
- Three of the projects have direct references to the Visual Studio 2013 toolset (one with WinXP extensions).  These were easy to update directly with the VS2015 IDE. After that, all indication on the various project property dialog windows indicates that the projects were correctly configured for VS2015. 

- However, the solution still would not compile.

- Seven of projects include various '_Reference Projects_', which are additional, internal, linkages to other inter-dependent projects.  This is in addition to the normal linkage to the projects that are explicitly part of the solution.

An example of '_Reference Projects_' (this is just one of the seven projects) ...

![2017-03-23_cr_cr](https://cloud.githubusercontent.com/assets/11866074/24274754/8bef7912-0fe7-11e7-9e60-101042772980.png)

- Within the text of the xxx.2015.vcxproj files, **these '_Reference Projects_' still refer to the older xxx.2013.vcxproj files**, thus requiring the co-existence of the VS2013 compiler. 

### Solution:

- Three projects were directly updated via the VS2015 IDE to use the VS2015 toolset.

- I could find no way to update the other seven projects' references directly via the IDE.  Possibly deleting and re-adding them would have worked, however that seemed tedious and error-prone.  By using the NotePad++ text editor on each of the xxx.2015.vcxproj files, I found all literals `.2013.` and changed them to `.2015.` 

- The entire solution now compiles correctly with the VS2015 compiler, without the existence of the VS2013 toolset.

### Testing:
- All configurations of the solution (Win32/x64 and Release/Debug) compile correctly, producing appropriate **FreeImageLib.lib** or **FreeImageLibd.lib**  files.  
- Using these new .lib files, the [WinIMerge](https://github.com/sdottaka/winimerge) solution compiles correctly in all configurations, producing (among other things) the proper **WinIMerge.dll** files.  
- The [WinMerge-v2](https://github.com/sdottaka/winmerge-v2) project runs correctly in all configurations using these new **WinIMerge.dll** files.
- Testing was done on **Win10**.  I have no way to test Windows XP, Vista, 7, 8 or 8.1,  but _I believe that there are no "breaking changes"._