### PR TITLE
Compile FreeImage with C++17 language rules.

### DIFF
--- a/FreeImage.vs2017.vcxproj
+++ b/FreeImage.vs2017.vcxproj
@@ -124,6 +124,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <FunctionLevelLinking>false</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -183,6 +184,7 @@ copy Source\FreeImage.h Dist\x32
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <FunctionLevelLinking>false</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -237,6 +239,7 @@ copy Source\FreeImage.h Dist\x64
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -291,6 +294,7 @@ copy Source\FreeImage.h Dist\x32
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <FunctionLevelLinking>true</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Source/FreeImage/MultiPage.cpp
+++ b/Source/FreeImage/MultiPage.cpp
@@ -251,7 +251,7 @@ FreeImage_OpenMultiBitmap(FREE_IMAGE_FORMAT fif, const char *filename, BOOL crea
 			PluginNode *node = list->FindNodeFromFIF(fif);
 
 			if (node) {
-				std::auto_ptr<FreeImageIO> io (new FreeImageIO);
+				std::unique_ptr<FreeImageIO> io (new FreeImageIO);
 
 				SetDefaultIO(io.get());
 
@@ -262,8 +262,8 @@ FreeImage_OpenMultiBitmap(FREE_IMAGE_FORMAT fif, const char *filename, BOOL crea
 					}
 				}
 
-				std::auto_ptr<FIMULTIBITMAP> bitmap (new FIMULTIBITMAP);
-				std::auto_ptr<MULTIBITMAPHEADER> header (new MULTIBITMAPHEADER);
+				std::unique_ptr<FIMULTIBITMAP> bitmap (new FIMULTIBITMAP);
+				std::unique_ptr<MULTIBITMAPHEADER> header (new MULTIBITMAPHEADER);
 				header->m_filename = new char[strlen(filename) + 1];
 				strcpy(header->m_filename, filename);
 				header->node = node;
@@ -296,7 +296,7 @@ FreeImage_OpenMultiBitmap(FREE_IMAGE_FORMAT fif, const char *filename, BOOL crea
 					std::string cache_name;
 					ReplaceExtension(cache_name, filename, "ficache");
 
-					std::auto_ptr<CacheFile> cache_file (new CacheFile(cache_name, keep_cache_in_memory));
+					std::unique_ptr<CacheFile> cache_file (new CacheFile(cache_name, keep_cache_in_memory));
 
 					if (cache_file->open()) {
 						// we can use release() as std::bad_alloc won't be thrown from here on
@@ -336,9 +336,9 @@ FreeImage_OpenMultiBitmapFromHandle(FREE_IMAGE_FORMAT fif, FreeImageIO *io, fi_h
 				PluginNode *node = list->FindNodeFromFIF(fif);
 			
 				if (node) {
-					std::auto_ptr<FIMULTIBITMAP> bitmap (new FIMULTIBITMAP);
-					std::auto_ptr<MULTIBITMAPHEADER> header (new MULTIBITMAPHEADER);
-					std::auto_ptr<FreeImageIO> tmp_io (new FreeImageIO (*io));
+					std::unique_ptr<FIMULTIBITMAP> bitmap (new FIMULTIBITMAP);
+					std::unique_ptr<MULTIBITMAPHEADER> header (new MULTIBITMAPHEADER);
+					std::unique_ptr<FreeImageIO> tmp_io (new FreeImageIO (*io));
 					header->io = tmp_io.get();
 					header->m_filename = NULL;
 					header->node = node;
@@ -364,7 +364,7 @@ FreeImage_OpenMultiBitmapFromHandle(FREE_IMAGE_FORMAT fif, FreeImageIO *io, fi_h
 
 					if (!read_only) {
 						// set up the cache
-						std::auto_ptr<CacheFile> cache_file (new CacheFile("", TRUE));
+						std::unique_ptr<CacheFile> cache_file (new CacheFile("", TRUE));
 						
 						if (cache_file->open()) {
 							header->m_cachefile = cache_file.release();

--- a/Source/FreeImageLib/FreeImageLib.vs2017.vcxproj
+++ b/Source/FreeImageLib/FreeImageLib.vs2017.vcxproj
@@ -103,6 +103,7 @@
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <FunctionLevelLinking>true</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -143,6 +144,7 @@ copy ..\FreeImage.h ..\..\Dist\x32
       <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FunctionLevelLinking>true</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -185,6 +187,7 @@ copy ..\FreeImage.h ..\..\Dist\x64
       <DebugInformationFormat>None</DebugInformationFormat>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <FunctionLevelLinking>false</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -229,6 +232,7 @@ copy ..\FreeImage.h ..\..\Dist\x32
       <DebugInformationFormat>None</DebugInformationFormat>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Source/LibRawLite/libraw/libraw_datastream.h
+++ b/Source/LibRawLite/libraw/libraw_datastream.h
@@ -87,14 +87,14 @@ class DllDef LibRaw_abstract_datastream
 };
 
 #ifdef WIN32
-template class DllDef std::auto_ptr<std::streambuf>;
+template class DllDef std::unique_ptr<std::streambuf>;
 #endif
 
 class DllDef  LibRaw_file_datastream: public LibRaw_abstract_datastream
 {
   protected:
-    std::auto_ptr<std::streambuf> f; /* will close() automatically through dtor */
-    std::auto_ptr<std::streambuf> saved_f; /* when *f is a subfile, *saved_f is the master file */
+    std::unique_ptr<std::streambuf> f; /* will close() automatically through dtor */
+    std::unique_ptr<std::streambuf> saved_f; /* when *f is a subfile, *saved_f is the master file */
     std::string filename;
     INT64 _fsize;
 #ifdef WIN32

--- a/Source/LibRawLite/src/libraw_datastream.cpp
+++ b/Source/LibRawLite/src/libraw_datastream.cpp
@@ -81,10 +81,10 @@ LibRaw_file_datastream::LibRaw_file_datastream(const char *fname)
         _fsize = st.st_size;
 #endif
       
-      std::auto_ptr<std::filebuf> buf(new std::filebuf());
+      std::unique_ptr<std::filebuf> buf(new std::filebuf());
       buf->open(filename.c_str(), std::ios_base::in | std::ios_base::binary);
       if (buf->is_open()) {
-        f = buf;
+        f.reset(buf.release());
       }
     }
 }
@@ -96,10 +96,10 @@ LibRaw_file_datastream::LibRaw_file_datastream(const wchar_t *fname) : filename(
       struct _stati64 st;
       if(!_wstati64(wfilename.c_str(),&st))
         _fsize = st.st_size;
-      std::auto_ptr<std::filebuf> buf(new std::filebuf());
+      std::unique_ptr<std::filebuf> buf(new std::filebuf());
       buf->open(wfilename.c_str(), std::ios_base::in | std::ios_base::binary);
       if (buf->is_open()) {
-        f = buf;
+        f.reset(buf.release());
       }
     }
 }
@@ -198,15 +198,15 @@ int LibRaw_file_datastream::subfile_open(const char *fn)
 {
     LR_STREAM_CHK();
     if (saved_f.get()) return EBUSY;
-    saved_f = f;
-        std::auto_ptr<std::filebuf> buf(new std::filebuf());
+    saved_f.reset(f.release());
+        std::unique_ptr<std::filebuf> buf(new std::filebuf());
         
         buf->open(fn, std::ios_base::in | std::ios_base::binary);
         if (!buf->is_open()) {
-            f = saved_f;
+            f.reset(saved_f.release());
             return ENOENT;
         } else {
-            f = buf;
+            f.reset(buf.release());
         }
         
         return 0;
@@ -217,15 +217,15 @@ int LibRaw_file_datastream::subfile_open(const wchar_t *fn)
 {
 	LR_STREAM_CHK();
 	if (saved_f.get()) return EBUSY;
-	saved_f = f;
-	std::auto_ptr<std::filebuf> buf(new std::filebuf());
+	saved_f.reset(f.release());
+	std::unique_ptr<std::filebuf> buf(new std::filebuf());
 
 	buf->open(fn, std::ios_base::in | std::ios_base::binary);
 	if (!buf->is_open()) {
-		f = saved_f;
+		f.reset(saved_f.release());
 		return ENOENT;
 	} else {
-		f = buf;
+		f.reset(buf.release());
 	}
 
 	return 0;
@@ -236,7 +236,7 @@ int LibRaw_file_datastream::subfile_open(const wchar_t *fn)
 void LibRaw_file_datastream::subfile_close()
 { 
     if (!saved_f.get()) return; 
-    f = saved_f;   
+    f.reset(saved_f.release());  
 }
 
 #undef LR_STREAM_CHK

--- a/Source/OpenEXR/Half/half.h
+++ b/Source/OpenEXR/Half/half.h
@@ -459,7 +459,7 @@ half::half (float f)
 	// to do the float-to-half conversion.
 	//
 
-	register int e = (x.i >> 23) & 0x000001ff;
+	int e = (x.i >> 23) & 0x000001ff;
 
 	e = _eLut[e];
 
@@ -470,7 +470,7 @@ half::half (float f)
 	    // bits and combine it with the sign and exponent.
 	    //
 
-	    register int m = x.i & 0x007fffff;
+	    int m = x.i & 0x007fffff;
 	    _h = e + ((m + 0x00000fff + ((m >> 13) & 1)) >> 13);
 	}
 	else

--- a/Source/OpenEXR/IlmThread/IlmThread.cpp
+++ b/Source/OpenEXR/IlmThread/IlmThread.cpp
@@ -62,7 +62,7 @@ Thread::Thread ()
 }
 
 
-Thread::~Thread ()
+Thread::~Thread () noexcept(false)
 {
     throw IEX_NAMESPACE::NoImplExc ("Threads not supported on this platform.");
 }

--- a/Source/OpenEXR/IlmThread/IlmThread.h
+++ b/Source/OpenEXR/IlmThread/IlmThread.h
@@ -120,7 +120,7 @@ class ILMTHREAD_EXPORT Thread
   public:
 
     Thread ();
-    virtual ~Thread ();
+    virtual ~Thread () noexcept(false);
 
     void		start ();
     virtual void	run () = 0;

--- a/Source/OpenEXR/Imath/ImathVec.cpp
+++ b/Source/OpenEXR/Imath/ImathVec.cpp
@@ -149,7 +149,7 @@ Vec2<short>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec2<short> &
-Vec2<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec2<short>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -180,7 +180,7 @@ Vec2<short>::normalized () const
 template <>
 IMATH_EXPORT
 Vec2<short>
-Vec2<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec2<short>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -225,7 +225,7 @@ Vec2<int>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec2<int> &
-Vec2<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec2<int>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -256,7 +256,7 @@ Vec2<int>::normalized () const
 template <>
 IMATH_EXPORT
 Vec2<int>
-Vec2<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec2<int>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -301,7 +301,7 @@ Vec3<short>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec3<short> &
-Vec3<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec3<short>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -332,7 +332,7 @@ Vec3<short>::normalized () const
 template <>
 IMATH_EXPORT
 Vec3<short>
-Vec3<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec3<short>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -377,7 +377,7 @@ Vec3<int>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec3<int> &
-Vec3<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec3<int>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -408,7 +408,7 @@ Vec3<int>::normalized () const
 template <>
 IMATH_EXPORT
 Vec3<int>
-Vec3<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec3<int>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -453,7 +453,7 @@ Vec4<short>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec4<short> &
-Vec4<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec4<short>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -484,7 +484,7 @@ Vec4<short>::normalized () const
 template <>
 IMATH_EXPORT
 Vec4<short>
-Vec4<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec4<short>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -529,7 +529,7 @@ Vec4<int>::normalize ()
 template <>
 IMATH_EXPORT
 const Vec4<int> &
-Vec4<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec4<int>::normalizeExc () noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");
@@ -560,7 +560,7 @@ Vec4<int>::normalized () const
 template <>
 IMATH_EXPORT
 Vec4<int>
-Vec4<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec4<int>::normalizedExc () const noexcept(false)
 {
     if ((x == 0) && (y == 0) && (z == 0) && (w == 0))
         throw NullVecExc ("Cannot normalize null vector.");

--- a/Source/OpenEXR/Imath/ImathVec.h
+++ b/Source/OpenEXR/Imath/ImathVec.h
@@ -225,11 +225,11 @@ template <class T> class Vec2
     T			length2 () const;
 
     const Vec2 &	normalize ();           // modifies *this
-    const Vec2 &	normalizeExc () throw (IEX_NAMESPACE::MathExc);
+    const Vec2 &	normalizeExc () noexcept(false);
     const Vec2 &	normalizeNonNull ();
 
     Vec2<T>		normalized () const;	// does not modify *this
-    Vec2<T>		normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+    Vec2<T>		normalizedExc () const noexcept(false);
     Vec2<T>		normalizedNonNull () const;
 
 
@@ -437,11 +437,11 @@ template <class T> class Vec3
     T			length2 () const;
 
     const Vec3 &	normalize ();           // modifies *this
-    const Vec3 &	normalizeExc () throw (IEX_NAMESPACE::MathExc);
+    const Vec3 &	normalizeExc () noexcept(false);
     const Vec3 &	normalizeNonNull ();
 
     Vec3<T>		normalized () const;	// does not modify *this
-    Vec3<T>		normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+    Vec3<T>		normalizedExc () const noexcept(false);
     Vec3<T>		normalizedNonNull () const;
 
 
@@ -619,11 +619,11 @@ template <class T> class Vec4
     T               length2 () const;
 
     const Vec4 &    normalize ();           // modifies *this
-    const Vec4 &    normalizeExc () throw (IEX_NAMESPACE::MathExc);
+    const Vec4 &    normalizeExc () noexcept(false);
     const Vec4 &    normalizeNonNull ();
 
     Vec4<T>         normalized () const;	// does not modify *this
-    Vec4<T>         normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+    Vec4<T>         normalizedExc () const noexcept(false);
     Vec4<T>         normalizedNonNull () const;
 
 
@@ -711,7 +711,7 @@ template <> const Vec2<short> &
 Vec2<short>::normalize ();
 
 template <> const Vec2<short> &
-Vec2<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec2<short>::normalizeExc () noexcept(false);
 
 template <> const Vec2<short> &
 Vec2<short>::normalizeNonNull ();
@@ -720,7 +720,7 @@ template <> Vec2<short>
 Vec2<short>::normalized () const;
 
 template <> Vec2<short>
-Vec2<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec2<short>::normalizedExc () const noexcept(false);
 
 template <> Vec2<short>
 Vec2<short>::normalizedNonNull () const;
@@ -735,7 +735,7 @@ template <> const Vec2<int> &
 Vec2<int>::normalize ();
 
 template <> const Vec2<int> &
-Vec2<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec2<int>::normalizeExc () noexcept(false);
 
 template <> const Vec2<int> &
 Vec2<int>::normalizeNonNull ();
@@ -744,7 +744,7 @@ template <> Vec2<int>
 Vec2<int>::normalized () const;
 
 template <> Vec2<int>
-Vec2<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec2<int>::normalizedExc () const noexcept(false);
 
 template <> Vec2<int>
 Vec2<int>::normalizedNonNull () const;
@@ -759,7 +759,7 @@ template <> const Vec3<short> &
 Vec3<short>::normalize ();
 
 template <> const Vec3<short> &
-Vec3<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec3<short>::normalizeExc () noexcept(false);
 
 template <> const Vec3<short> &
 Vec3<short>::normalizeNonNull ();
@@ -768,7 +768,7 @@ template <> Vec3<short>
 Vec3<short>::normalized () const;
 
 template <> Vec3<short>
-Vec3<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec3<short>::normalizedExc () const noexcept(false);
 
 template <> Vec3<short>
 Vec3<short>::normalizedNonNull () const;
@@ -783,7 +783,7 @@ template <> const Vec3<int> &
 Vec3<int>::normalize ();
 
 template <> const Vec3<int> &
-Vec3<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec3<int>::normalizeExc () noexcept(false);
 
 template <> const Vec3<int> &
 Vec3<int>::normalizeNonNull ();
@@ -792,7 +792,7 @@ template <> Vec3<int>
 Vec3<int>::normalized () const;
 
 template <> Vec3<int>
-Vec3<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec3<int>::normalizedExc () const noexcept(false);
 
 template <> Vec3<int>
 Vec3<int>::normalizedNonNull () const;
@@ -806,7 +806,7 @@ template <> const Vec4<short> &
 Vec4<short>::normalize ();
 
 template <> const Vec4<short> &
-Vec4<short>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec4<short>::normalizeExc () noexcept(false);
 
 template <> const Vec4<short> &
 Vec4<short>::normalizeNonNull ();
@@ -815,7 +815,7 @@ template <> Vec4<short>
 Vec4<short>::normalized () const;
 
 template <> Vec4<short>
-Vec4<short>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec4<short>::normalizedExc () const noexcept(false);
 
 template <> Vec4<short>
 Vec4<short>::normalizedNonNull () const;
@@ -830,7 +830,7 @@ template <> const Vec4<int> &
 Vec4<int>::normalize ();
 
 template <> const Vec4<int> &
-Vec4<int>::normalizeExc () throw (IEX_NAMESPACE::MathExc);
+Vec4<int>::normalizeExc () noexcept(false);
 
 template <> const Vec4<int> &
 Vec4<int>::normalizeNonNull ();
@@ -839,7 +839,7 @@ template <> Vec4<int>
 Vec4<int>::normalized () const;
 
 template <> Vec4<int>
-Vec4<int>::normalizedExc () const throw (IEX_NAMESPACE::MathExc);
+Vec4<int>::normalizedExc () const noexcept(false);
 
 template <> Vec4<int>
 Vec4<int>::normalizedNonNull () const;
@@ -1209,7 +1209,7 @@ Vec2<T>::normalize ()
 
 template <class T>
 const Vec2<T> &
-Vec2<T>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec2<T>::normalizeExc () noexcept(false)
 {
     T l = length();
 
@@ -1246,7 +1246,7 @@ Vec2<T>::normalized () const
 
 template <class T>
 Vec2<T>
-Vec2<T>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec2<T>::normalizedExc () const noexcept(false)
 {
     T l = length();
 
@@ -1701,7 +1701,7 @@ Vec3<T>::normalize ()
 
 template <class T>
 const Vec3<T> &
-Vec3<T>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec3<T>::normalizeExc () noexcept(false)
 {
     T l = length();
 
@@ -1740,7 +1740,7 @@ Vec3<T>::normalized () const
 
 template <class T>
 Vec3<T>
-Vec3<T>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec3<T>::normalizedExc () const noexcept(false)
 {
     T l = length();
 
@@ -2106,7 +2106,7 @@ Vec4<T>::normalize ()
 
 template <class T>
 const Vec4<T> &
-Vec4<T>::normalizeExc () throw (IEX_NAMESPACE::MathExc)
+Vec4<T>::normalizeExc () noexcept(false)
 {
     T l = length();
 
@@ -2147,7 +2147,7 @@ Vec4<T>::normalized () const
 
 template <class T>
 Vec4<T>
-Vec4<T>::normalizedExc () const throw (IEX_NAMESPACE::MathExc)
+Vec4<T>::normalizedExc () const noexcept(false)
 {
     T l = length();
 

--- a/TestAPI/Test.vs2017.vcxproj
+++ b/TestAPI/Test.vs2017.vcxproj
@@ -107,6 +107,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -142,6 +143,7 @@
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -178,6 +180,7 @@
       <UseUnicodeForAssemblerListing>false</UseUnicodeForAssemblerListing>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -214,6 +217,7 @@
       <WarningLevel>Level3</WarningLevel>
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Wrapper/FreeImagePlus/FreeImagePlus.vs2017.vcxproj
+++ b/Wrapper/FreeImagePlus/FreeImagePlus.vs2017.vcxproj
@@ -127,6 +127,7 @@
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <FunctionLevelLinking>false</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -173,6 +174,7 @@ copy FreeImagePlus.h dist\x32
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <FunctionLevelLinking>false</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -214,6 +216,7 @@ copy FreeImagePlus.h dist\x64</Command>
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName)d.pdb</ProgramDataBaseFileName>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -266,6 +269,7 @@ copy FreeImagePlus.h dist\x32
       <DebugInformationFormat>EditAndContinue</DebugInformationFormat>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <ProgramDataBaseFileName>$(IntDir)$(ProjectName)d.pdb</ProgramDataBaseFileName>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/Wrapper/FreeImagePlus/test/fipTest.vs2017.vcxproj
+++ b/Wrapper/FreeImagePlus/test/fipTest.vs2017.vcxproj
@@ -106,6 +106,7 @@
       <AdditionalIncludeDirectories>..\..\..\Dist\x32</AdditionalIncludeDirectories>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -144,6 +145,7 @@
       <AdditionalIncludeDirectories>..\..\..\Dist\x32</AdditionalIncludeDirectories>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <EnableEnhancedInstructionSet>StreamingSIMDExtensions</EnableEnhancedInstructionSet>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -178,6 +180,7 @@
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <AdditionalIncludeDirectories>..\..\..\Dist\x64</AdditionalIncludeDirectories>
       <FunctionLevelLinking>true</FunctionLevelLinking>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
@@ -214,6 +217,7 @@
       <SuppressStartupBanner>true</SuppressStartupBanner>
       <AdditionalIncludeDirectories>..\..\..\Dist\x64</AdditionalIncludeDirectories>
       <IntrinsicFunctions>true</IntrinsicFunctions>
+      <LanguageStandard>stdcpp17</LanguageStandard>
     </ClCompile>
     <ResourceCompile>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>


### PR DESCRIPTION
 * Force the **FreeImage**, **FreeImageLib** and **FreeImagePlus** projects, and the **Test** and **fipTest** solutions,  to be compiled with **C++17** language semantics when using **VS2017**.

 * Use `unique_ptr<>` to replace `auto_ptr<>`
 * `unique_ptr<>` requires that ...
	`stream_ptr = buf_ptr;`
   be expressed as ...
	`stream_ptr.reset(buf_ptr.release());`
   in situations where `stream_ptr` is a `std::streambuf` and `buf_ptr` is a `std::filebuf`. Note: this is only within the **LibRaw** sub-project (which is never (?) actually used the WinMerge or WinIMerge projects).
 * `register` is eliminated; it has been "meaningless" for a very-very long time.
 * `throw` as a function declarator has been deprecated since **C++11**, in favor of the newer `noexcept` syntax.  Both forms have been acceptable in **C++14**, but **C++17** no longer accepts the old `throw` declarator.  These are now all fixed **OpenEXR** sub-project

* The **FreeImage**, **FreeImageLib** and **FreeImagePlus** continue to compile correctly with **VS2015**.  The **Test** and **fipTest** continue to compile and execute correctly with **VS2015**.