### PR TITLE
E2K: fixed build by MCST lcc compiler (MCST Elbrus 2000 architecture)

### DIFF
--- a/Source/OpenEXR/IlmImf/ImfFastHuf.cpp
+++ b/Source/OpenEXR/IlmImf/ImfFastHuf.cpp
@@ -307,9 +307,9 @@ FastHufDecoder::enabled()
         // Enabled for ICC, GCC:
         //       __i386__   -> x86
         //       __x86_64__ -> 64-bit x86
-        //
+        //       __e2k__    -> e2k (MCST Elbrus 2000)
 
-        #if defined (__i386__) || defined(__x86_64__)
+        #if defined (__i386__) || defined(__x86_64__) || defined(__e2k__)
             return true;
         #else
             return false;

--- a/Source/OpenEXR/IlmImf/ImfSimd.h
+++ b/Source/OpenEXR/IlmImf/ImfSimd.h
@@ -48,6 +48,27 @@
     #define IMF_HAVE_SSE2 1
 #endif
 
+// Compiler flags on e2k (MCST Elbrus 2000) architecture
+#if defined(__SSE3__) && defined(__e2k__)
+    #define IMF_HAVE_SSE3 1
+#endif
+
+#if defined(__SSSE3__) && defined(__e2k__)
+    #define IMF_HAVE_SSSE3 1
+#endif
+
+#if defined(__SSE4_2__) && defined(__e2k__)
+    #define IMF_HAVE_SSE4_2 1
+#endif
+
+#if defined(__AVX__) && defined(__e2k__)
+    #define IMF_HAVE_AVX 1
+#endif
+
+#if defined(__F16C__) && defined(__e2k__)
+    #define IMF_HAVE_F16C 1
+#endif
+
 extern "C"
 {
 #if IMF_HAVE_SSE2

--- a/Source/OpenEXR/IlmImf/ImfSystemSpecific.cpp
+++ b/Source/OpenEXR/IlmImf/ImfSystemSpecific.cpp
@@ -39,19 +39,19 @@
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_ENTER
 
 namespace {
-#if defined(IMF_HAVE_SSE2) &&  defined(__GNUC__)
+#if defined(IMF_HAVE_SSE2) &&  defined(__GNUC__) && !defined(__e2k__)
 
     // Helper functions for gcc + SSE enabled
     void cpuid(int n, int &eax, int &ebx, int &ecx, int &edx)
     {
         __asm__ __volatile__ (
             "cpuid"
-            : /* Output  */ "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx) 
+            : /* Output  */ "=a"(eax), "=b"(ebx), "=c"(ecx), "=d"(edx)
             : /* Input   */ "a"(n)
             : /* Clobber */);
     }
 
-#else // IMF_HAVE_SSE2 && __GNUC__
+#else // IMF_HAVE_SSE2 && __GNUC__ && !__e2k__
 
     // Helper functions for generic compiler - all disabled
     void cpuid(int n, int &eax, int &ebx, int &ecx, int &edx)
@@ -59,7 +59,7 @@ namespace {
         eax = ebx = ecx = edx = 0;
     }
 
-#endif // IMF_HAVE_SSE2 && __GNUC__
+#endif // IMF_HAVE_SSE2 && __GNUC__ && !__e2k__
 
 
 #ifdef OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX
@@ -68,7 +68,7 @@ namespace {
     {
         __asm__ __volatile__ (
             "xgetbv"
-            : /* Output  */ "=a"(eax), "=d"(edx) 
+            : /* Output  */ "=a"(eax), "=d"(edx)
             : /* Input   */ "c"(n)
             : /* Clobber */);
     }
@@ -82,7 +82,7 @@ namespace {
 
 #endif //  OPENEXR_IMF_HAVE_GCC_INLINE_ASM_AVX
 
-} // namespace 
+} // namespace
 
 CpuId::CpuId():
     sse2(false), 
@@ -93,6 +93,30 @@ CpuId::CpuId():
     avx(false), 
     f16c(false)
 {
+#if defined(__e2k__) // e2k - MCST Elbrus 2000 architecture
+    // Use IMF_HAVE definitions to determine e2k CPU features
+#   if defined(IMF_HAVE_SSE2)
+        sse2 = true;
+#   endif
+#   if defined(IMF_HAVE_SSE3)
+        sse3 = true;
+#   endif
+#   if defined(IMF_HAVE_SSSE3)
+        ssse3 = true;
+#   endif
+#   if defined(IMF_HAVE_SSE4_1)
+        sse4_1 = true;
+#   endif
+#   if defined(IMF_HAVE_SSE4_2)
+        sse4_2 = true;
+#   endif
+#   if defined(IMF_HAVE_AVX)
+        avx = true;
+#   endif
+#   if defined(IMF_HAVE_F16C)
+        f16c = true;
+#   endif
+#else // x86/x86_64
     bool osxsave = false;
     int  max     = 0;
     int  eax, ebx, ecx, edx;
@@ -124,6 +148,7 @@ CpuId::CpuId():
             }
         }
     }
+#endif
 }
 
 OPENEXR_IMF_INTERNAL_NAMESPACE_SOURCE_EXIT


### PR DESCRIPTION
backport from OpenEXR

Ref: https://github.com/AcademySoftwareFoundation/openexr/pull/862

Ref: https://en.wikipedia.org/wiki/Elbrus_2000